### PR TITLE
Hub 2.2.0-rc1

### DIFF
--- a/files/brews/hub.rb
+++ b/files/brews/hub.rb
@@ -1,0 +1,20 @@
+require 'formula'
+
+class Hub < Formula
+  homepage "http://hub.github.com/"
+  url "https://github.com/github/hub/releases/download/v2.2.0-rc1/hub-mac-amd64-2.2.0-rc1.tar.gz"
+  sha1 "413ce80d32f6313cef010e0edb1e664e1fff7427"
+
+  def install
+    bin.install "hub"
+    man1.install Dir["man/*"]
+    bash_completion.install "etc/hub.bash_completion.sh"
+    zsh_completion.install "etc/hub.zsh_completion" => "_hub"
+  end
+
+  test do
+    HOMEBREW_REPOSITORY.cd do
+      assert shell_output("#{bin}/hub version").split("\n").include?("hub version #{version}")
+    end
+  end
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,8 +17,10 @@ class hub(
 
       include boxen::config
 
-      package { 'hub':
-        ensure => latest
+      homebrew::formula { 'hub': }
+
+      package { 'boxen/brews/hub':
+        ensure => latest,
       }
 
       git::config::global { 'hub.protocol':

--- a/spec/classes/hub_spec.rb
+++ b/spec/classes/hub_spec.rb
@@ -15,7 +15,7 @@ describe 'hub' do
   end
 
   it { should include_class('boxen::config') }
-  it { should contain_package('hub').with_ensure('latest') }
+  it { should contain_package('boxen/brews/hub').with_ensure('latest') }
 
   it 'sets up hub.sh file' do
     should contain_file("#{env_dir}/hub.sh")


### PR DESCRIPTION
We'd like to provide a way for boxen users to try out `hub` [v2.2.0-rc1](https://github.com/github/hub/releases/tag/v2.2.0-rc1). I borrow some ideas from https://github.com/boxen/puppet-gh to fork the [official hub recipe](https://github.com/Homebrew/homebrew/blob/master/Library/Formula/hub.rb) to a file and refer to it in the boxen init script. But I'll be happy to learn if there's a way to avoid duplicating the recipe. We'd like boxen users to run `brew install --HEAD hub` which builds from source.

/cc @mislav