### PR TITLE
Add Ruby 2.0.0 to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ bundler_args: "--path .bundle --binstubs .bundle/binstubs"
 script: "script/cibuild"
 rvm:
   - "1.8.7"
+  - "2.0.0"
 cache:
   directories:
   - ".bundle"


### PR DESCRIPTION
Since different versions of OSX have either 1.8.7 and 2.0.0 for their system ruby, I thought it might be a good idea to have both when testing on CI.

/cc @mislav @mikemcquaid 