### PR TITLE
Add support for updating hub to latest version from Homebrew, fixes #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ You can use hiera to configure the following:
   Protocol for `hub` to use by default when cloning from github like `hub clone user/repo`. Defaults to `'https'`
 * `hub::alias_hub_to_git`: boolean
   Whether or not to set a shell alias `git=hub`
+* `hub::package_name`: the package name to use when installing hub. . Defaults to `'boxen/brews/hub'`. Use `'hub'` to install the latest version of hub from homebrew.
 
 ## Required Puppet Modules
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,6 +7,7 @@ class hub(
   $ensure           = 'present',
   $alias_hub_to_git = true,
   $protocol         = 'https',
+  $package_name     = 'boxen/brews/hub',
 ) {
 
   case $ensure {
@@ -19,7 +20,7 @@ class hub(
 
       homebrew::formula { 'hub': }
 
-      package { 'boxen/brews/hub':
+      package { $package_name :
         ensure => latest,
       }
 
@@ -43,7 +44,7 @@ class hub(
     }
 
     absent: {
-      package { 'hub':
+      package { $package_name :
         ensure => absent
       }
 

--- a/spec/classes/hub_spec.rb
+++ b/spec/classes/hub_spec.rb
@@ -24,4 +24,12 @@ describe 'hub' do
   it 'sets up global hub protocal config option' do
     should contain_git__config__global('hub.protocol').with_value('https')
   end
+
+  context "package_name is hub" do
+    let(:params) {
+      { :package_name => "hub" }
+    }
+
+    it { should contain_package('hub').with_ensure('latest') }
+  end
 end


### PR DESCRIPTION
cc @mislav 
This PR introduce ``package_name``,  the package name to use when installing hub. It defaults to `'boxen/brews/hub'`. Use the value `'hub'` to install the latest version of hub from homebrew.

```puppet
class { 'hub':
  package_name => 'hub'
}
```
Thanks